### PR TITLE
channel: add basic implementation for create/delete

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1,0 +1,44 @@
+package multicam
+
+// #include <multicam.h>
+// #include <stdlib.h>
+import "C"
+
+const UninitializedChannel = 0
+
+type Channel struct {
+	channel C.MCHANDLE
+}
+
+// NewChannel creates a new Multicam Channel.
+func NewChannel() *Channel {
+	return &Channel{}
+}
+
+// Create creates a new MultiCam Channel object.
+func (c *Channel) Create() error {
+	if c.channel != UninitializedChannel {
+		return ErrInvalidChannel
+	}
+
+	status := C.McCreate(C.MC_CHANNEL, &c.channel)
+	if status != C.MC_OK {
+		return ErrCannotCreateChannel
+	}
+
+	return nil
+}
+
+// Delete deletes an existing MultiCam Channel object.
+func (c *Channel) Delete() error {
+	if c.channel == UninitializedChannel {
+		return ErrInvalidChannel
+	}
+
+	status := C.McDelete(c.channel)
+	if status != C.MC_OK {
+		return ErrCannotDeleteChannel
+	}
+
+	return nil
+}

--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,10 @@ package multicam
 import "errors"
 
 var (
-	ErrCannotOpenDriver = errors.New("cannot open driver")
-	ErrCannotSetParam   = errors.New("cannot set param")
-	ErrCannotGetParam   = errors.New("cannot get param")
+	ErrCannotOpenDriver    = errors.New("cannot open driver")
+	ErrCannotSetParam      = errors.New("cannot set param")
+	ErrCannotGetParam      = errors.New("cannot get param")
+	ErrInvalidChannel      = errors.New("invalid channel")
+	ErrCannotCreateChannel = errors.New("cannot create MultiCam channel")
+	ErrCannotDeleteChannel = errors.New("cannot delete MultiCam channel")
 )


### PR DESCRIPTION
This PR adds very basic support for MultiCam "channels" which are used to capture data from each connected frame grabber.