### PR TITLE
surface: Add Ptr() and ToBytes() functions for easier direct data access

### DIFF
--- a/examples/capture/main.go
+++ b/examples/capture/main.go
@@ -5,10 +5,8 @@ import (
 	"image"
 	"image/jpeg"
 	"os"
-	"reflect"
 	"strings"
 	"time"
-	"unsafe"
 
 	mc "github.com/northvolt/go-multicam"
 )
@@ -131,18 +129,11 @@ func cbhandler(info *mc.SignalInfo) {
 	switch mc.ParamID(info.Signal) {
 	case mc.SurfaceProcessingSignal:
 		s := mc.SurfaceForHandle(mc.Handle(info.SignalInfo))
-		pimg, err := s.GetParamPtr(mc.SurfaceAddrParam)
+		ptr, err := s.Ptr(x, y)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		fmt.Println("frame received at address", pimg)
-		h := &reflect.SliceHeader{
-			Data: uintptr(pimg),
-			Len:  int(x * y),
-			Cap:  int(x * y),
-		}
-		ptr := *(*[]byte)(unsafe.Pointer(h))
 
 		img := image.NewGray(image.Rect(0, 0, x, y))
 		img.Pix = ptr

--- a/examples/metadata/main.go
+++ b/examples/metadata/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"reflect"
 	"time"
-	"unsafe"
 
 	mc "github.com/northvolt/go-multicam"
 )
@@ -142,18 +140,11 @@ func cbhandler(info *mc.SignalInfo) {
 	switch mc.ParamID(info.Signal) {
 	case mc.SurfaceProcessingSignal:
 		s := mc.SurfaceForHandle(mc.Handle(info.SignalInfo))
-		pimg, err := s.GetParamPtr(mc.SurfaceAddrParam)
+		ptr, err := s.Ptr(x, y)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		fmt.Println("frame received at address", pimg)
-		h := &reflect.SliceHeader{
-			Data: uintptr(pimg),
-			Len:  int(x * y),
-			Cap:  int(x * y),
-		}
-		ptr := *(*[]byte)(unsafe.Pointer(h))
 
 		md, err := mc.ParseMetadata(content, ptr)
 		if err != nil {

--- a/examples/multi/main.go
+++ b/examples/multi/main.go
@@ -5,10 +5,8 @@ import (
 	"image"
 	"image/jpeg"
 	"os"
-	"reflect"
 	"strings"
 	"time"
-	"unsafe"
 
 	mc "github.com/northvolt/go-multicam"
 )
@@ -182,18 +180,11 @@ func (g *grabber) cbhandler(info *mc.SignalInfo) {
 	switch mc.ParamID(info.Signal) {
 	case mc.SurfaceProcessingSignal:
 		s := mc.SurfaceForHandle(mc.Handle(info.SignalInfo))
-		pimg, err := s.GetParamPtr(mc.SurfaceAddrParam)
+		ptr, err := s.Ptr(g.x, g.y)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		fmt.Println("frame received at address", pimg)
-		h := &reflect.SliceHeader{
-			Data: uintptr(pimg),
-			Len:  int(g.x * g.y),
-			Cap:  int(g.x * g.y),
-		}
-		ptr := *(*[]byte)(unsafe.Pointer(h))
 
 		img := image.NewGray(image.Rect(0, 0, g.x, g.y))
 		img.Pix = ptr


### PR DESCRIPTION
This PR adds a `ToBytes()` function to the Surface type. This makes it more straightforward on how to get to the actual image dat.

It should be merged after PR https://github.com/northvolt/go-multicam/pull/8