### PR TITLE
version: add functions to return package and SDK version (with caveats)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM ubuntu:20.04 AS multicam-base
 
 ARG MULTICAM_RELEASE=6.18.4.4961
+ENV MULTICAM_SDK_VERSION=$MULTICAM_RELEASE
 
 RUN apt-get update && apt-get install -y apt-file file make gcc linux-headers-5.15.0-46-generic wget
 COPY multicam-linux/multicam-linux-x86_64-${MULTICAM_RELEASE}.tar.gz /

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -19,6 +19,8 @@ func main() {
 	}
 
 	fmt.Println("Driver was opened...")
+	fmt.Println("Go Multicam version", mc.Version(), mc.SDKVersion())
+
 	bc, err := mc.GetParamInt(mc.ConfigurationHandle, mc.BoardCountParam)
 	if err != nil {
 		fmt.Println(err)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,20 @@
+package multicam
+
+import "os"
+
+// GoMulticamVersion of this package, for display purposes.
+// Change this variable on a new package release.
+const GoMulticamVersion = "0.1.0-dev"
+
+// Version returns the current Golang package version.
+func Version() string {
+	return GoMulticamVersion
+}
+
+// SDKVersion returns the current SDK version using an ENV variable, since not supported by Euresys directly.
+// It can be set automatically within a Docker container built using ARG/ENV variables, as is done by the
+// Dockerfile located in this package.
+// If not set by the host or by container, it will return empty string.
+func SDKVersion() string {
+	return os.Getenv("MULTICAM_SDK_VERSION")
+}


### PR DESCRIPTION
This PR adds functions to return the package and SDK version, with the caveat that since the Multicam SDK itself cannot return the SDK version at this time, an ENV var is used instead.