### PR TITLE
examples: add flags to select board for capture, or which board is primary/secondary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,12 @@ ARG EXAMPLE=basic
 
 COPY . /src/github.com/northvolt/go-multicam
 WORKDIR /src/github.com/northvolt/go-multicam
-RUN go build -o /basic ./examples/basic/ && \
-    go build -o /blink ./examples/blink/ && \
-    go build -o /capture ./examples/capture/ && \
-    go build  -o /metadata ./examples/metadata/ && \
-    go build -o /multi ./examples/multi/ && \
-    go build  -o /multisignal ./examples/multisignal/ 
+RUN mkdir -p /build && \
+    go build -o /build/basic ./examples/basic/ && \
+    go build -o /build/blink ./examples/blink/ && \
+    go build -o /build/capture ./examples/capture/ && \
+    go build  -o /build/metadata ./examples/metadata/ && \
+    go build -o /build/multi ./examples/multi/ && \
+    go build  -o /build/multisignal ./examples/multisignal/
 
-ENTRYPOINT ["${EXAMPLE}"]
+ENTRYPOINT ["/build/${EXAMPLE}"]

--- a/examples/capture/main.go
+++ b/examples/capture/main.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	camfile = flag.String("camfile", "", "CAM file to use for capture")
+	board   = flag.Int("board", 0, "board number to use for capture (default 0)")
 
 	x, y, pitch int
 	ch          *mc.Channel
@@ -40,7 +41,7 @@ func main() {
 	fmt.Println("Driver was opened...")
 
 	// Get board
-	brd := mc.BoardForIndex(1)
+	brd := mc.BoardForIndex(*board)
 
 	//  Create a channel for board.
 	var err error

--- a/examples/metadata/main.go
+++ b/examples/metadata/main.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	camfile = flag.String("camfile", "", "CAM file to use for capture")
+	board   = flag.Int("board", 0, "board number to use for capture (default 0)")
 
 	x, y, pitch, content int
 	ch                   *mc.Channel
@@ -36,7 +37,7 @@ func main() {
 	fmt.Println("Driver was opened...")
 
 	// Get board
-	brd := mc.BoardForIndex(1)
+	brd := mc.BoardForIndex(*board)
 
 	//  Create a channel for board.
 	var err error

--- a/examples/multi/main.go
+++ b/examples/multi/main.go
@@ -15,6 +15,8 @@ import (
 var (
 	camfilePrimary   = flag.String("camfile-primary", "", "CAM file to use for primary board capture")
 	camfileSecondary = flag.String("camfile-secondary", "", "CAM file to use for secondary board capture")
+	primary          = flag.Int("primary", 0, "board number to use as primary for capture (default 0)")
+	secondary        = flag.Int("secondary", 1, "board number to use as secondary for capture (default 1)")
 )
 
 func main() {
@@ -46,14 +48,14 @@ func main() {
 	fmt.Println("Boards detected:", bc)
 
 	// Create grabber for each board
-	g2, err := createGrabber(1, *camfileSecondary)
+	g2, err := createGrabber(*secondary, *camfileSecondary)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
 	// primary last
-	g1, err := createGrabber(0, *camfilePrimary)
+	g1, err := createGrabber(*primary, *camfilePrimary)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/examples/multisignal/main.go
+++ b/examples/multisignal/main.go
@@ -20,6 +20,8 @@ type pair struct {
 var (
 	camfilePrimary   = flag.String("camfile-primary", "", "CAM file to use for primary board capture")
 	camfileSecondary = flag.String("camfile-secondary", "", "CAM file to use for secondary board capture")
+	primary          = flag.Int("primary", 0, "board number to use as primary for capture (default 0)")
+	secondary        = flag.Int("secondary", 1, "board number to use as secondary for capture (default 1)")
 	numberSurfaces   = flag.Int("number-surfaces", 10, "number of surfaces for each channel/board. defaults to 10")
 	height           = flag.Int("height", 1000, "frame height. defaults to 1000")
 	width            = flag.Int("width", 7320, "width of single grabber. defaults to 7320")
@@ -56,14 +58,14 @@ func main() {
 	fmt.Println("Boards detected:", bc)
 
 	// Create grabber for each board
-	g1, err := createGrabber(0, *camfilePrimary)
+	g1, err := createGrabber(*primary, *camfilePrimary)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	g1.primary = true
 
-	g2, err := createGrabber(1, *camfileSecondary)
+	g2, err := createGrabber(*secondary, *camfileSecondary)
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
This PR modifies the examples to add flags to select board for capture, or which board is primary/secondary for multiple card capture.