### PR TITLE
docker: switch to build CMD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .github/
 .vscode/
 Dockerfile*
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 build
 .DS_Store
 .vscode/
-multicam-linux-*/
+multicam-linux/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ RUN mkdir -p /build && \
     go build -o /build/multi ./examples/multi/ && \
     go build  -o /build/multisignal ./examples/multisignal/
 
-ENTRYPOINT ["/build/${EXAMPLE}"]
+CMD ["/build/${EXAMPLE}"]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ FULL_XR_929
 Done.
 ```
 
+You can copy the compiled binary executables out of the container, and run them directly on host computers that are running Linux and have the correct Euresys drivers installed.
+
+```
+mkdir -p ./build
+docker run -it -v $(pwd)/build:/hostbuild -t multicam:latest /bin/bash -c "cp /build/* /hostbuild/"
+```
 
 ## Why it exists
 


### PR DESCRIPTION
This PR switches the docker container that is built with the examples to use `CMD` instead of `ENTRYPOINT` to simplify the docker command needed to copy the completed binary executables out of the container and onto a host system. 