### PR TITLE
metadata: handle flipped metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ARG EXAMPLE=basic
 COPY . /src/github.com/northvolt/go-multicam
 WORKDIR /src/github.com/northvolt/go-multicam
 RUN go get golang.org/x/tools/cmd/stringer && go generate .
+RUN go test -v
 RUN mkdir -p /build && \
     go build -o /build/basic ./examples/basic/ && \
     go build -o /build/blink ./examples/blink/ && \

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,119 @@
+package multicam
+
+import "testing"
+
+func TestParseOneField(t *testing.T) {
+	content := MetadataContentOneField
+	data := []byte{16, 1, 2, 3}
+
+	md, err := ParseMetadata(content, data)
+	if err != nil {
+		t.Error("unable to parse metadata content")
+	}
+	if md.content != MetadataContentOneField {
+		t.Error("invalid metadata content")
+	}
+	if !md.DIN1() {
+		t.Error("DIN1 should have been set")
+	}
+}
+
+func TestParseOneFieldFlipped(t *testing.T) {
+	content := MetadataContentOneField
+	data := []byte{1, 2, 3, 16}
+
+	md, err := ParseMetadataFlipped(content, data)
+	if err != nil {
+		t.Error("unable to parse metadata content")
+	}
+	if md.content != MetadataContentOneField {
+		t.Error("invalid metadata content")
+	}
+	if !md.DIN1() {
+		t.Error("DIN1 should have been set")
+	}
+}
+
+func TestParseTwoField(t *testing.T) {
+	content := MetadataContentTwoField
+	data := []byte{16, 0x00, 72, 0x00, 0x00, 0x00, 1, 2, 3}
+
+	md, err := ParseMetadata(content, data)
+	if err != nil {
+		t.Error("unable to parse metadata content")
+	}
+	if md.content != MetadataContentTwoField {
+		t.Error("invalid metadata content")
+	}
+	if !md.DIN1() {
+		t.Error("DIN1 should have been set")
+	}
+	if md.Count() != 72 {
+		t.Error("invalid count", md.Count(), "should be 72")
+	}
+}
+
+func TestParseTwoFieldFlipped(t *testing.T) {
+	content := MetadataContentTwoField
+	data := []byte{3, 2, 1, 0x00, 0x00, 0x00, 72, 0x00, 16}
+
+	md, err := ParseMetadataFlipped(content, data)
+	if err != nil {
+		t.Error("unable to parse metadata content")
+	}
+	if md.content != MetadataContentTwoField {
+		t.Error("invalid metadata content")
+	}
+	if !md.DIN1() {
+		t.Error("DIN1 should have been set")
+	}
+	if md.Count() != 72 {
+		t.Error("invalid count", md.Count(), "should be 72")
+	}
+}
+
+func TestParseThreeField(t *testing.T) {
+	content := MetadataContentThreeField
+	data := []byte{16, 0x00, 72, 0x00, 0x00, 0x00, 42, 0x00, 0x00, 0x00, 1, 2, 3, 4}
+
+	md, err := ParseMetadata(content, data)
+	if err != nil {
+		t.Error("unable to parse metadata content")
+	}
+	if md.content != MetadataContentThreeField {
+		t.Error("invalid metadata content")
+	}
+	if !md.DIN1() {
+		t.Error("DIN1 should have been set")
+	}
+	if md.Count() != 42 {
+		t.Error("invalid count", md.Count(), "should be 42")
+	}
+
+	if md.Qcount() != 72 {
+		t.Error("invalid Qcount", md.Qcount(), "should be 72")
+	}
+}
+
+func TestParseThreeFieldFlipped(t *testing.T) {
+	content := MetadataContentThreeField
+	data := []byte{3, 2, 1, 0x00, 0x00, 0x00, 42, 0x00, 0x00, 0x00, 72, 0x00, 16}
+
+	md, err := ParseMetadataFlipped(content, data)
+	if err != nil {
+		t.Error("unable to parse metadata content")
+	}
+	if md.content != MetadataContentThreeField {
+		t.Error("invalid metadata content")
+	}
+	if !md.DIN1() {
+		t.Error("DIN1 should have been set")
+	}
+	if md.Count() != 42 {
+		t.Error("invalid count", md.Count(), "should be 42")
+	}
+
+	if md.Qcount() != 72 {
+		t.Error("invalid Qcount", md.Qcount(), "should be 72")
+	}
+}


### PR DESCRIPTION
This PR adds a new function `ParseMetadataFlipped()` to handle parsing metadata then the image has been flipped on the X-axis. It also adds some unit tests, and executes them on building the Dockerfile. As a result it also fixes an errors in the previous `ParseMetadata()` function.