### PR TITLE
examples/capture, metadata: add needed triggering to start up capture

### DIFF
--- a/examples/capture/main.go
+++ b/examples/capture/main.go
@@ -81,6 +81,11 @@ func main() {
 		fmt.Println("Done.")
 	}()
 
+	if err := ch.SetParamStr(mc.ForceTrigParam, "TRIG"); err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	for {
 		time.Sleep(time.Second)
 	}

--- a/examples/metadata/main.go
+++ b/examples/metadata/main.go
@@ -78,6 +78,11 @@ func main() {
 		fmt.Println("Done.")
 	}()
 
+	if err := ch.SetParamStr(mc.ForceTrigParam, "TRIG"); err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	for {
 		time.Sleep(time.Second)
 	}


### PR DESCRIPTION
This PR adds needed initial triggering to start up capture that was missing to the "capture" and "metadata" examples.